### PR TITLE
Issues with hashes in message

### DIFF
--- a/pynexmo.py
+++ b/pynexmo.py
@@ -28,7 +28,7 @@ def __url_fix(s, charset='utf-8'):
     scheme, netloc, path, qs, anchor = urlparse.urlsplit(s)
     path = urllib.quote(path, '/%')
     qs = urllib.quote_plus(qs, ':&=')
-    return urlparse.urlunsplit((scheme, netloc, path, qs, anchor))
+    return urlparse.urlunsplit((scheme, netloc, path, qs, anchor)).replace("#","%23")
 
 
 def __url_fetch(url):


### PR DESCRIPTION
I escaped hashes in the message since when they are in, the API returns an error. (at least if the message begins with a hash)
